### PR TITLE
Upgraded to aws sdk version 2.1.17

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,12 +1,12 @@
 Package.describe({
   summary: "SDK for AWS services including Amazon S3, Amazon EC2, DynamoDB, and Amazon SWF",
-  version: '2.1.14_2',
+  version: '2.1.17_1',
   name: 'peerlibrary:aws-sdk',
   git: 'https://github.com/peerlibrary/meteor-aws-sdk.git'
 });
 
 Npm.depends({
-  'aws-sdk': '2.1.14'
+  'aws-sdk': '2.1.17'
 });
 
 Package.on_use(function (api) {


### PR DESCRIPTION
I got an email from amazon saying that 2.1.13, 2.1.14, and 2.1.15 have memory issues when downloading files from S3